### PR TITLE
Improved test for non GET request on GET mock

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,11 @@ describe('mockRequests()', function () {
         .put('/api')
         .expect(200)
         .expect('not mocked', done);
+      
+      request(server)
+        .post('/api')
+        .expect(200)
+        .expect('not mocked', done);
     })
   });
 


### PR DESCRIPTION
The test code seems to mock GET requests as GET and POST requests. I've currently no idea why, but added the missing test to ensure the correct behaviour.
