### PR TITLE
Adds calls endpoint to access list of mock calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git@github.com:xebia/mock-rest-request.git"
   },
   "scripts": {
+    "tdd": "nodemon --exec 'mocha || true'",
     "test": "mocha"
   },
   "keywords": [
@@ -24,7 +25,9 @@
   },
   "homepage": "https://github.com/xebia/mock-rest-request",
   "devDependencies": {
+    "chai": "^4.1.2",
     "mocha": "^1.20.1",
+    "nodemon": "^1.12.5",
     "supertest": "^0.13.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var request = require('supertest');
+var expect = require('chai').expect;
 
 var mockRequests = require('..');
 
@@ -144,6 +145,40 @@ describe('mockRequests()', function () {
       .expect(200)
       .expect('GET:\n /api\nPUT:\nPOST:\nPATCH:\nDELETE:\n', done);
   });
+
+  it('should list past calls and data', function(done) {
+
+    request(server)
+      .post('/mock/api/items')
+      .set('mock-method', 'POST')
+      .send({message: 'created'})
+      .expect(200)
+      .end(function () {});
+
+    request(server)
+      .post('/api/items')
+      .send({some:'data'})
+      .expect(200)
+      .expect('{"mock":"data"}')
+      .end(function () {});
+
+    request(server)
+      .get('/calls')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end(function(err,res){
+        var data = JSON.parse(res.text);
+        expect(data).to.deep.equal([{
+          method: 'POST',
+          url: '/api/items',
+          data: {
+            some: 'data'
+          }
+        }]);
+        done(err);
+      });
+
+  })
 
 });
 


### PR DESCRIPTION
I am going to use this mock rest server for use in our testing and would like the ability to check which endpoints have been called. I have added a very basic endpoint which can be used to check all the calls that have been made against the server to give behaviour assertions against the calls on the server. 

The following points I was unsure about when creating the server and would appreciate feedback:
1. Should calls be recorded per mocked request or globally as implemented?
2. Should the reset endpoint also reset the record of calls?

Feedback very welcome and requirement for edits expected.